### PR TITLE
Undo the update to 8.2.3 due to incompatibility for ZADE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
-### 4.8.2.3.0
-- This version of the adapter has been certified with Digital Turbine Exchange SDK 8.2.3.
-
 ### 4.8.2.2.1
 - Updated the dependency on Chartboost Mediation SDK to 4.0.0.
 

--- a/DigitalTurbineExchangeAdapter/build.gradle.kts
+++ b/DigitalTurbineExchangeAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.8.2.3.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.8.2.2.1"
         buildConfigField("String", "CHARTBOOST_MEDIATION_DIGITAL_TURBINE_EXCHANGE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -70,7 +70,7 @@ dependencies {
     "remoteImplementation"("com.chartboost:chartboost-mediation-sdk:4.0.0")
 
     // Partner SDK
-    implementation("com.fyber:marketplace-sdk:8.2.3")
+    implementation("com.fyber:marketplace-sdk:8.2.2")
 
     // Adapter Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Digital Turbine Exchange adapter mediates Digital Turbi
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.3.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.1.1"
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Digital Turbine Exchange adapter mediates Digital Turbi
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.1.1"
+    implementation "com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.2.1"
 ```
 
 ## Contributions


### PR DESCRIPTION
Revert "[HB-5631] Digital Turbine 8.2.3 (#36)"

This reverts commit 0bb5d59971f2ae33f7a4b1bc9a7c882490e8ee5a.

[HB-5631]: https://chartboost.atlassian.net/browse/HB-5631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ