### PR TITLE
[HB-7187] Update Digital Turbine Exchange adapter to perform `setUp` on `IO` instead of `Main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.8.2.5.2
+- Performs initialization on `IO` to help reduce potential ANR issues.
+
 ### 4.8.2.5.1
 - Fix memory leaks that could occur when fullscreen ads are shown from an `Activity`.
 

--- a/DigitalTurbineExchangeAdapter/build.gradle.kts
+++ b/DigitalTurbineExchangeAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.8.2.5.1"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.8.2.5.2"
         buildConfigField(
             "String",
             "CHARTBOOST_MEDIATION_DIGITAL_TURBINE_EXCHANGE_ADAPTER_VERSION",

--- a/DigitalTurbineExchangeAdapter/src/main/java/com/chartboost/mediation/digitalturbineexchangeadapter/DigitalTurbineExchangeAdapter.kt
+++ b/DigitalTurbineExchangeAdapter/src/main/java/com/chartboost/mediation/digitalturbineexchangeadapter/DigitalTurbineExchangeAdapter.kt
@@ -19,7 +19,7 @@ import com.fyber.inneractive.sdk.external.*
 import com.fyber.inneractive.sdk.external.InneractiveAdSpot.RequestListener
 import com.fyber.inneractive.sdk.external.InneractiveUnitController.AdDisplayError
 import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -154,7 +154,7 @@ class DigitalTurbineExchangeAdapter : PartnerAdapter {
     override suspend fun setUp(
         context: Context,
         partnerConfiguration: PartnerConfiguration,
-    ): Result<Unit> = withContext(Dispatchers.IO) {
+    ): Result<Unit> = withContext(IO) {
         PartnerLogController.log(SETUP_STARTED)
 
         return@withContext suspendCancellableCoroutine { continuation ->

--- a/DigitalTurbineExchangeAdapter/src/main/java/com/chartboost/mediation/digitalturbineexchangeadapter/DigitalTurbineExchangeAdapter.kt
+++ b/DigitalTurbineExchangeAdapter/src/main/java/com/chartboost/mediation/digitalturbineexchangeadapter/DigitalTurbineExchangeAdapter.kt
@@ -19,7 +19,9 @@ import com.fyber.inneractive.sdk.external.*
 import com.fyber.inneractive.sdk.external.InneractiveAdSpot.RequestListener
 import com.fyber.inneractive.sdk.external.InneractiveUnitController.AdDisplayError
 import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -152,10 +154,10 @@ class DigitalTurbineExchangeAdapter : PartnerAdapter {
     override suspend fun setUp(
         context: Context,
         partnerConfiguration: PartnerConfiguration,
-    ): Result<Unit> {
+    ): Result<Unit> = withContext(Dispatchers.IO) {
         PartnerLogController.log(SETUP_STARTED)
 
-        return suspendCancellableCoroutine { continuation ->
+        return@withContext suspendCancellableCoroutine { continuation ->
             fun resumeOnce(result: Result<Unit>) {
                 if (continuation.isActive) {
                     continuation.resume(result)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Digital Turbine Exchange adapter mediates Digital Turbi
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.5.1"
+    implementation "com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.5.2"
 ```
 
 ## Contributions


### PR DESCRIPTION
To reduce the potential of ANRs, the adapter `setUp` method has been changed to be perform the work on the `IO` coroutine context.