### PR TITLE
Updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+All official releases can be found on this repository's [releases page](https://github.com/ChartBoost/chartboost-mediation-android-adapter-digital-turbine-exchange/releases).
+
+### 4.8.3.1.0
+- This version of the adapter has been certified with Digital Turbine Exchange SDK 8.3.1.
+
 ### 5.8.3.0.0
 - This version of the adapter has been certified with Digital Turbine Exchange SDK 8.3.0.
 - This version of the adapter supports Chartboost Mediation SDK version 5.+.


### PR DESCRIPTION
Retroactively update the CHANGELOG to include a link to the official releases page on Github and with Mediation 4 releases (if necessary).